### PR TITLE
Initialize Blues House trainer header bit

### DIFF
--- a/scripts/BluesHouse.asm
+++ b/scripts/BluesHouse.asm
@@ -24,6 +24,10 @@ BluesHouse_TextPointers:
 	dw_const BluesHouseDaisyWalkingText, TEXT_BLUESHOUSE_DAISY_WALKING
 	dw_const BluesHouseTownMapText,      TEXT_BLUESHOUSE_TOWN_MAP
 
+BluesHouseTrainerHeaders:
+	def_trainers 3
+	db -1 ; end
+
 BluesHouseDaisySittingText:
 	text_asm
 	CheckEvent EVENT_GOT_TOWN_MAP


### PR DESCRIPTION
## Summary
- add a Blues House trainer header definition and initialize it at bit 3 to align with EVENT_BEAT_PROF_OAK.

## Testing
- make *(fails: rgbasm is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9031ac28832db70e3883027df737