### PR TITLE
Fix BluesHouse trainer table duplication

### DIFF
--- a/scripts/BluesHouse.asm
+++ b/scripts/BluesHouse.asm
@@ -86,10 +86,6 @@ BluesHouse_TextPointers:
         dw_const BluesHouseTownMapText,      TEXT_BLUESHOUSE_TOWN_MAP
         dw_const BluesHouseOakText,          TEXT_BLUESHOUSE_OAK
 
-BluesHouseTrainerHeaders:
-	def_trainers 3
-	db -1 ; end
-
 BluesHouseDaisySittingText:
 	text_asm
 	CheckEvent EVENT_GOT_TOWN_MAP
@@ -165,7 +161,7 @@ BluesHouseOakText:
         jp TextScriptEnd
 
 BluesHouseTrainerHeaders:
-        def_trainers
+        def_trainers 3
 ProfOakTrainerHeader:
         trainer EVENT_BEAT_PROF_OAK, 0, BluesHouseOakBattleText, BluesHouseOakDefeatedText, BluesHouseOakAfterBattleText
         db -1 ; end


### PR DESCRIPTION
## Summary
- remove the redundant BluesHouseTrainerHeaders stub inserted above Daisy's text pointers
- set the actual BluesHouse trainer table to use `def_trainers 3` for the Prof. Oak encounter

## Testing
- `make` *(fails: rgbasm missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9915c27c832d921dc9cc154953b4