### PR TITLE
Refactor map object helpers into ROMX bank

### DIFF
--- a/engine/overworld/map_object_helpers.asm
+++ b/engine/overworld/map_object_helpers.asm
@@ -1,0 +1,88 @@
+DecodeArrowMovementRLE_::
+        ld a, [hli]
+        cp $ff
+        ret z ; no match in the list
+        cp b
+        jr nz, .nextArrowMovementTileEntry1
+        ld a, [hli]
+        cp c
+        jr nz, .nextArrowMovementTileEntry2
+        ld a, [hli]
+        ld d, [hl]
+        ld e, a
+        ld hl, wSimulatedJoypadStatesEnd
+        call DecodeRLEList_
+        dec a
+        ld [wSimulatedJoypadStatesIndex], a
+        ret
+.nextArrowMovementTileEntry1
+        inc hl
+.nextArrowMovementTileEntry2
+        inc hl
+        inc hl
+        jr DecodeArrowMovementRLE_
+
+DecodeRLEList_::
+        xor a
+        ld [wRLEByteCount], a     ; count written bytes here
+.listLoop
+        ld a, [de]
+        cp $ff
+        jr z, .endOfList
+        ldh [hRLEByteValue], a ; store byte value to be written
+        inc de
+        ld a, [de]
+        ld b, $0
+        ld c, a                      ; number of bytes to be written
+        ld a, [wRLEByteCount]
+        add c
+        ld [wRLEByteCount], a     ; update total number of written bytes
+        ldh a, [hRLEByteValue]
+        call FillMemory              ; write a c-times to output
+        inc de
+        jr .listLoop
+.endOfList
+        ld a, $ff
+        ld [hl], a                   ; write final $ff
+        ld a, [wRLEByteCount]
+        inc a                        ; include sentinel in counting
+        ret
+
+SetSpriteMovementBytesToFE_::
+        push hl
+        call GetSpriteMovementByte1Pointer_
+        ld [hl], $fe
+        call GetSpriteMovementByte2Pointer_
+        ldh a, [hSpriteMovementByte2]
+        ld [hl], a
+        pop hl
+        ret
+
+SetSpriteMovementBytesToFF_::
+        push hl
+        call GetSpriteMovementByte1Pointer_
+        ld [hl], STAY
+        call GetSpriteMovementByte2Pointer_
+        ld [hl], NONE
+        pop hl
+        ret
+
+GetSpriteMovementByte1Pointer_::
+        ld h, HIGH(wSpriteStateData2)
+        ldh a, [hSpriteIndex]
+        swap a
+        add 6
+        ld l, a
+        ret
+
+GetSpriteMovementByte2Pointer_::
+        push de
+        ld hl, wMapSpriteData
+        ldh a, [hSpriteIndex]
+        dec a
+        add a
+        ld d, 0
+        ld e, a
+        add hl, de
+        pop de
+        ret

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -3,28 +3,7 @@
 ; b = player Y
 ; c = player X
 DecodeArrowMovementRLE::
-	ld a, [hli]
-	cp $ff
-	ret z ; no match in the list
-	cp b
-	jr nz, .nextArrowMovementTileEntry1
-	ld a, [hli]
-	cp c
-	jr nz, .nextArrowMovementTileEntry2
-	ld a, [hli]
-	ld d, [hl]
-	ld e, a
-	ld hl, wSimulatedJoypadStatesEnd
-	call DecodeRLEList
-	dec a
-	ld [wSimulatedJoypadStatesIndex], a
-	ret
-.nextArrowMovementTileEntry1
-	inc hl
-.nextArrowMovementTileEntry2
-	inc hl
-	inc hl
-	jr DecodeArrowMovementRLE
+        farjp DecodeArrowMovementRLE_
 
 TextScript_ItemStoragePC::
 	call SaveScreenTilesToBuffer2
@@ -177,70 +156,20 @@ _GetPointerWithinSpriteStateData:
 ; de: input list
 ; hl: output list
 DecodeRLEList::
-	xor a
-	ld [wRLEByteCount], a     ; count written bytes here
-.listLoop
-	ld a, [de]
-	cp $ff
-	jr z, .endOfList
-	ldh [hRLEByteValue], a ; store byte value to be written
-	inc de
-	ld a, [de]
-	ld b, $0
-	ld c, a                      ; number of bytes to be written
-	ld a, [wRLEByteCount]
-	add c
-	ld [wRLEByteCount], a     ; update total number of written bytes
-	ldh a, [hRLEByteValue]
-	call FillMemory              ; write a c-times to output
-	inc de
-	jr .listLoop
-.endOfList
-	ld a, $ff
-	ld [hl], a                   ; write final $ff
-	ld a, [wRLEByteCount]
-	inc a                        ; include sentinel in counting
-	ret
+        farjp DecodeRLEList_
 
 ; sets movement byte 1 for sprite [hSpriteIndex] to $FE and byte 2 to [hSpriteMovementByte2]
 SetSpriteMovementBytesToFE::
-	push hl
-	call GetSpriteMovementByte1Pointer
-	ld [hl], $fe
-	call GetSpriteMovementByte2Pointer
-	ldh a, [hSpriteMovementByte2]
-	ld [hl], a
-	pop hl
-	ret
+        farjp SetSpriteMovementBytesToFE_
 
 ; sets both movement bytes for sprite [hSpriteIndex] to $FF
 SetSpriteMovementBytesToFF::
-	push hl
-	call GetSpriteMovementByte1Pointer
-	ld [hl], STAY
-	call GetSpriteMovementByte2Pointer
-	ld [hl], NONE
-	pop hl
-	ret
+        farjp SetSpriteMovementBytesToFF_
 
 ; returns the sprite movement byte 1 pointer for sprite [hSpriteIndex] in hl
 GetSpriteMovementByte1Pointer::
-	ld h, HIGH(wSpriteStateData2)
-	ldh a, [hSpriteIndex]
-	swap a
-	add 6
-	ld l, a
-	ret
+        farjp GetSpriteMovementByte1Pointer_
 
 ; returns the sprite movement byte 2 pointer for sprite [hSpriteIndex] in hl
 GetSpriteMovementByte2Pointer::
-	push de
-	ld hl, wMapSpriteData
-	ldh a, [hSpriteIndex]
-	dec a
-	add a
-	ld d, 0
-	ld e, a
-	add hl, de
-	pop de
-	ret
+        farjp GetSpriteMovementByte2Pointer_

--- a/main.asm
+++ b/main.asm
@@ -115,6 +115,7 @@ INCLUDE "engine/play_time.asm"
 
 SECTION "Doors and Ledges", ROMX
 
+INCLUDE "engine/overworld/map_object_helpers.asm"
 INCLUDE "engine/overworld/auto_movement.asm"
 INCLUDE "engine/overworld/doors.asm"
 INCLUDE "engine/overworld/ledges.asm"


### PR DESCRIPTION
## Summary
- replace the home bank implementations of the map object helper routines with far jumps
- move the helper logic into a new Doors and Ledges bank file and reference the renamed symbols
- include the new helper source from the existing Doors and Ledges ROMX section to keep everything linked together

## Testing
- `make` *(fails: rgbasm missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9d1f7d0c832da86210fdd0db3208