### PR TITLE
Move sprite data pointer helpers out of Home

### DIFF
--- a/engine/overworld/map_object_helpers.asm
+++ b/engine/overworld/map_object_helpers.asm
@@ -86,3 +86,19 @@ GetSpriteMovementByte2Pointer_::
         add hl, de
         pop de
         ret
+
+GetPointerWithinSpriteStateData1_::
+        ld h, HIGH(wSpriteStateData1)
+        jr GetPointerWithinSpriteStateDataCommon_
+
+GetPointerWithinSpriteStateData2_::
+        ld h, HIGH(wSpriteStateData2)
+
+GetPointerWithinSpriteStateDataCommon_:
+        ldh a, [hSpriteDataOffset]
+        ld b, a
+        ldh a, [hSpriteIndex]
+        swap a
+        add b
+        ld l, a
+        ret

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -135,20 +135,10 @@ CheckBoulderCoords::
 	jp CheckCoords
 
 GetPointerWithinSpriteStateData1::
-	ld h, HIGH(wSpriteStateData1)
-	jr _GetPointerWithinSpriteStateData
+       farjp GetPointerWithinSpriteStateData1_
 
 GetPointerWithinSpriteStateData2::
-	ld h, HIGH(wSpriteStateData2)
-
-_GetPointerWithinSpriteStateData:
-	ldh a, [hSpriteDataOffset]
-	ld b, a
-	ldh a, [hSpriteIndex]
-	swap a
-	add b
-	ld l, a
-	ret
+       farjp GetPointerWithinSpriteStateData2_
 
 ; decodes a $ff-terminated RLEncoded list
 ; each entry is a pair of bytes <byte value> <repetitions>


### PR DESCRIPTION
## Summary
- replace the Home implementations of the sprite state data pointer helpers with far jump stubs
- add the relocated helper routines to the existing banked map object helper file so they assemble into ROMX

## Testing
- make *(fails: rgbasm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9b49a2e8832db331625d52ec314b