### PR TITLE
Export bag item quantity and item use text labels

### DIFF
--- a/engine/items/get_bag_item_quantity.asm
+++ b/engine/items/get_bag_item_quantity.asm
@@ -1,4 +1,4 @@
-GetQuantityOfItemInBag:
+GetQuantityOfItemInBag::
 ; In: b = item ID
 ; Out: b = how many of that item are in the bag
 	call GetPredefRegisters

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2355,7 +2355,7 @@ BoxFullCannotThrowBallText:
 	text_far _BoxFullCannotThrowBallText
 	text_end
 
-ItemUseText00:
+ItemUseText00::
 	text_far _ItemUseText001
 	text_low
 	text_far _ItemUseText002


### PR DESCRIPTION
## Summary
- export GetQuantityOfItemInBag so other objects can link to it
- export ItemUseText00 so Home's repel script can reference the text pointer

## Testing
- make *(fails: rgbasm not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb5e3bc6c832d9ad9958164b130bf