### PR TITLE
Adjust Oak movement into lab

### DIFF
--- a/engine/overworld/auto_movement.asm
+++ b/engine/overworld/auto_movement.asm
@@ -132,7 +132,7 @@ RLEList_ProfOakWalkToLab:
 	db NPC_MOVEMENT_LEFT, 1
 	db NPC_MOVEMENT_DOWN, 5
 	db NPC_MOVEMENT_RIGHT, 3
-	db NPC_MOVEMENT_UP, 1
+        db NPC_MOVEMENT_UP, 2
 	db NPC_CHANGE_FACING, 1
 	db -1 ; end
 


### PR DESCRIPTION
## Summary
- extend Professor Oak's scripted movement into the lab by one extra tile upward so he clears the doorway

## Testing
- make *(fails: `rgbasm` tool is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbeb68068832d930fc5bf2f30784f